### PR TITLE
Update to NS 8.4.0

### DIFF
--- a/src/index.android.ts
+++ b/src/index.android.ts
@@ -2,7 +2,7 @@ import { Application, Color, CoreTypes, FormattedString, Span, ViewBase, backgro
 import { Font, FontWeight } from '@nativescript/core/ui/styling/font';
 import { getTransformedText, textDecorationProperty } from '@nativescript/core/ui/text-base';
 import { LightFormattedString } from './index-common';
-import { layout } from '@nativescript/core/utils/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { ObjectSpans, getMaxFontSize } from '.';
 export * from './index-common';
 


### PR DESCRIPTION
Hi @farfromrefug ,

`layout` isn't part from `@nativescript/core/utils/utils` any more, it can be imported from `@nativescript/core/utils/layout-helper` but this is not backward compatible with NS 8.3 I think !