### PR TITLE
fix: type casting for Swift

### DIFF
--- a/packages/text/platforms/ios/src/NSTextUtils.swift
+++ b/packages/text/platforms/ios/src/NSTextUtils.swift
@@ -19,7 +19,7 @@ class NSTextUtils: NSObject {
       attrDict[NSAttributedString.Key.strikethroughStyle] = (NSUnderlineStyle.single)
     }
     
-    if letterSpacing != 0 && isTextType && (view as! UILabel).font != nil {
+    if letterSpacing != 0 && isTextType && view is UILabel && (view as! UILabel).font != nil {
       let kern:NSNumber! = NSNumber.init(value: letterSpacing * (view as! UILabel).font.pointSize)
       attrDict[NSAttributedString.Key.kern] = kern
     }
@@ -40,10 +40,8 @@ class NSTextUtils: NSObject {
     if (paragraphStyle != nil) {
       if (view is UIButton) {
         paragraphStyle.alignment = (view as! UIButton).titleLabel!.textAlignment
-      } else {
+      } else if (view is UILabel) {
         paragraphStyle.alignment = (view as! UILabel).textAlignment
-      }
-      if (view is UILabel) {
         // make sure a possible previously set line break mode is not lost when line height is specified
         paragraphStyle.lineBreakMode = (view as! UILabel).lineBreakMode
       }


### PR DESCRIPTION
Currently if attributes are made against TextField and other components, a Swift type cast issue can result and crash the app.
<img width="1233" alt="Screenshot 2024-01-03 at 3 23 18 PM" src="https://github.com/nativescript-community/text/assets/457187/10ccb95c-f362-4145-a8ea-4adf5eacda07">
<img width="1105" alt="Screenshot 2024-01-03 at 3 26 21 PM" src="https://github.com/nativescript-community/text/assets/457187/777ea870-447c-406e-842e-e9086db834c4">
